### PR TITLE
Fix copy mistakes and annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ npm install karma-benchmark karma-benchmarkjs-reporter --save-dev
 ```
 
 ## Karma Configuration
-Add `benchmark` to your `frameworks` and `reporters` arrays. Optionally, specify
+Add `benchmark` to your `frameworks` and `reporters` arrays. Optionally, specify a `benchmarkReporter` config object:
 ```js
 module.exports = function(config) {
   config.set({
@@ -54,7 +54,7 @@ This value is inherited from Karma, but you can override it by specifying a bool
 }
 ```
 
-The style object contains the styling functions for piece of data. The default uses [`chalk`](https://github.com/chalk/chalk) for styling and color.
+The style object contains the styling functions for each piece of data. The default uses [`chalk`](https://github.com/chalk/chalk) for styling and color.
 
 #### `decorator`
 *default:* `"-"`

--- a/src/formatting/format-benchmark.js
+++ b/src/formatting/format-benchmark.js
@@ -44,8 +44,8 @@ var getFormattedHzUnits = function (units, style) {
 /**
  * @param  {string} browserName the name of the browser
  * @param  {number} browserWidth the target width of the formatted browser name
- * @return {string} the formatted browser name
  * @param {Object} style object containing wrapper functions (e.g., chalk functions)
+ * @return {string} the formatted browser name
  * @private
  */
 var getFormattedBrowserName = function (browserName, browserWidth, style) {


### PR DESCRIPTION
- Fix copy in README
- Fix JSDoc annotation order for getFormattedBrowserName()
