### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,17 +32,18 @@
     "benchmarkjs"
   ],
   "dependencies": {
-    "chalk": "^1.1.3",
+    "chalk": "^2.4.2",
     "lodash": "^4.15.0",
-    "strip-ansi": "^3.0.1"
+    "strip-ansi": "5.0.0"
   },
   "devDependencies": {
-    "builder": "^3.0.0",
-    "chai": "^3.5.0",
-    "eslint": "^2.10.2",
-    "eslint-config-formidable": "^1.0.1",
+    "builder": "^4.0.0",
+    "chai": "^4.2.0",
+    "eslint": "^5.12.1",
+    "eslint-config-formidable": "^4.0.0",
     "eslint-plugin-filenames": "^1.1.0",
-    "eslint-plugin-import": "^1.14.0",
-    "mocha": "^3.0.2"
+    "eslint-plugin-import": "^2.15.0",
+    "eslint-plugin-promise": "4.0.1",
+    "mocha": "^5.2.0"
   }
 }

--- a/src/formatting/format-benchmark.js
+++ b/src/formatting/format-benchmark.js
@@ -12,9 +12,7 @@ var formatWithColorConfig = require("./helpers").formatWithColorConfig;
  * @private
  */
 var getFormattedDecorator = function (decorator, style) {
-  return style.decorator(
-    decorator + " "
-  );
+  return style.decorator(decorator + " ");
 };
 
 /**
@@ -25,9 +23,7 @@ var getFormattedDecorator = function (decorator, style) {
  * @private
  */
 var getFormattedHz = function (hz, hzWidth, style) {
-  return style.hz(
-    _.padStart(Math.round(hz), hzWidth)
-  );
+  return style.hz(_.padStart(Math.round(hz), hzWidth));
 };
 
 /**
@@ -37,9 +33,7 @@ var getFormattedHz = function (hz, hzWidth, style) {
  * @private
  */
 var getFormattedHzUnits = function (units, style) {
-  return style.hzUnits(
-    " " + units + " "
-  );
+  return style.hzUnits(" " + units + " ");
 };
 
 /**
@@ -50,9 +44,7 @@ var getFormattedHzUnits = function (units, style) {
  * @private
  */
 var getFormattedBrowserName = function (browserName, browserWidth, style) {
-  return style.browser(
-    _.padStart("[" + browserName + "]", browserWidth)
-  );
+  return style.browser(_.padStart("[" + browserName + "]", browserWidth));
 };
 
 /**
@@ -63,9 +55,7 @@ var getFormattedBrowserName = function (browserName, browserWidth, style) {
  * @private
  */
 var getFormattedBenchmarkName = function (benchmarkName, benchmarkWidth, style) {
-  return style.benchmark(
-    _.padEnd(benchmarkName, benchmarkWidth)
-  );
+  return style.benchmark(_.padEnd(benchmarkName, benchmarkWidth));
 };
 
 /**
@@ -96,9 +86,7 @@ var formatBenchmark = function (benchmark, browser, benchConfig) {
     : "";
   var benchmarkName = getFormattedBenchmarkName(
     benchmark.name,
-    getRemainingWidth(benchConfig.terminalWidth, [
-      decorator, hz, hzUnits, browserName
-    ]),
+    getRemainingWidth(benchConfig.terminalWidth, [decorator, hz, hzUnits, browserName]),
     style
   );
 

--- a/src/formatting/helpers.js
+++ b/src/formatting/helpers.js
@@ -1,11 +1,9 @@
 "use strict";
 
-var chalk = require("chalk");
+var stripAnsi = require("strip-ansi");
 
 var formatWithColorConfig = function (string, benchConfig) {
-  return !benchConfig.colors
-    ? chalk.stripColor(string)
-    : string;
+  return !benchConfig.colors ? stripAnsi(string) : string;
 };
 
 module.exports = {

--- a/src/formatting/style.js
+++ b/src/formatting/style.js
@@ -1,9 +1,10 @@
 "use strict";
 
 var chalk = require("chalk");
+var stripAnsi = require("strip-ansi");
 
 module.exports = {
-  benchmark: chalk.stripColor,
+  benchmark: stripAnsi,
   summaryBenchmark: chalk.underline,
   summaryEmphasis: chalk.bold.underline,
   browser: chalk.blue,

--- a/test/spec/formatting/format-benchmark.spec.js
+++ b/test/spec/formatting/format-benchmark.spec.js
@@ -1,5 +1,5 @@
 var expect = require("chai").expect;
-var chalk = require("chalk");
+var stripAnsi = require("strip-ansi");
 var EOL = require("os").EOL;
 var formatBenchmark = require("../../../src/formatting/format-benchmark");
 var sampleData = require("../sample-data");
@@ -18,8 +18,9 @@ describe("formatBenchmark()", function () {
   it("should format the benchmark", function () {
     var formattedBenchmark = formatBenchmark(benchmark, browser, benchConfig);
     expect(formattedBenchmark).to.equal(
-      "\u001b[36m- \u001b[39mbenchmark 1                                  " +
-      "\u001b[32m   1\u001b[39m\u001b[3m\u001b[2m ops/sec \u001b[22m\u001b[23m" + EOL
+      "\u001b[36m- \u001b[39mbenchmark 1                                  "
+        + "\u001b[32m   1\u001b[39m\u001b[3m\u001b[2m ops/sec \u001b[22m\u001b[23m"
+        + EOL
     );
   });
 
@@ -27,8 +28,9 @@ describe("formatBenchmark()", function () {
     benchConfig.showBrowser = true;
     var formattedBenchmark = formatBenchmark(benchmark, browser, benchConfig);
     expect(formattedBenchmark).to.equal(
-      "\u001b[36m- \u001b[39mbenchmark 1\u001b[32m   1\u001b[39m\u001b[3m\u001b[2m ops/sec " +
-      "\u001b[22m\u001b[23m\u001b[34m[PhantomJS 2.1.1 (Mac OS X 0.0.0)]\u001b[39m" + EOL
+      "\u001b[36m- \u001b[39mbenchmark 1\u001b[32m   1\u001b[39m\u001b[3m\u001b[2m ops/sec "
+        + "\u001b[22m\u001b[23m\u001b[34m[PhantomJS 2.1.1 (Mac OS X 0.0.0)]\u001b[39m"
+        + EOL
     );
   });
 
@@ -38,9 +40,10 @@ describe("formatBenchmark()", function () {
     benchConfig.browserWidth = 60;
     var formattedBenchmark = formatBenchmark(benchmark, browser, benchConfig);
     expect(formattedBenchmark).to.equal(
-      "\u001b[36m- \u001b[39mbenchmark 1                                                  " +
-      "          \u001b[32m   1\u001b[39m\u001b[3m\u001b[2m ops/sec \u001b[22m\u001b[23m" +
-      "\u001b[34m[PhantomJS 2.1.1 (Mac OS X 0.0.0)]\u001b[39m" + EOL
+      "\u001b[36m- \u001b[39mbenchmark 1                                                  "
+        + "          \u001b[32m   1\u001b[39m\u001b[3m\u001b[2m ops/sec \u001b[22m\u001b[23m"
+        + "\u001b[34m[PhantomJS 2.1.1 (Mac OS X 0.0.0)]\u001b[39m"
+        + EOL
     );
   });
 
@@ -48,8 +51,9 @@ describe("formatBenchmark()", function () {
     benchConfig.decorator = "*";
     var formattedBenchmark = formatBenchmark(benchmark, browser, benchConfig);
     expect(formattedBenchmark).to.equal(
-     "\u001b[36m* \u001b[39mbenchmark 1                                  " +
-     "\u001b[32m   1\u001b[39m\u001b[3m\u001b[2m ops/sec \u001b[22m\u001b[23m" + EOL
+      "\u001b[36m* \u001b[39mbenchmark 1                                  "
+        + "\u001b[32m   1\u001b[39m\u001b[3m\u001b[2m ops/sec \u001b[22m\u001b[23m"
+        + EOL
     );
   });
 
@@ -57,9 +61,10 @@ describe("formatBenchmark()", function () {
     benchConfig.terminalWidth = 100;
     var formattedBenchmark = formatBenchmark(benchmark, browser, benchConfig);
     expect(formattedBenchmark).to.equal(
-      "\u001b[36m- \u001b[39mbenchmark 1                                        " +
-      "                                  \u001b[32m   1\u001b[39m\u001b[3m\u001b" +
-      "[2m ops/sec \u001b[22m\u001b[23m" + EOL
+      "\u001b[36m- \u001b[39mbenchmark 1                                        "
+        + "                                  \u001b[32m   1\u001b[39m\u001b[3m\u001b"
+        + "[2m ops/sec \u001b[22m\u001b[23m"
+        + EOL
     );
   });
 
@@ -67,8 +72,9 @@ describe("formatBenchmark()", function () {
     benchConfig.hzWidth = 10;
     var formattedBenchmark = formatBenchmark(benchmark, browser, benchConfig);
     expect(formattedBenchmark).to.equal(
-      "\u001b[36m- \u001b[39mbenchmark 1                            \u001b[32m  " +
-      "       1\u001b[39m\u001b[3m\u001b[2m ops/sec \u001b[22m\u001b[23m" + EOL
+      "\u001b[36m- \u001b[39mbenchmark 1                            \u001b[32m  "
+        + "       1\u001b[39m\u001b[3m\u001b[2m ops/sec \u001b[22m\u001b[23m"
+        + EOL
     );
   });
 
@@ -76,8 +82,9 @@ describe("formatBenchmark()", function () {
     benchConfig.hzUnits = "ops per second";
     var formattedBenchmark = formatBenchmark(benchmark, browser, benchConfig);
     expect(formattedBenchmark).to.equal(
-      "\u001b[36m- \u001b[39mbenchmark 1                           \u001b[32m   " +
-      "1\u001b[39m\u001b[3m\u001b[2m ops per second \u001b[22m\u001b[23m" + EOL
+      "\u001b[36m- \u001b[39mbenchmark 1                           \u001b[32m   "
+        + "1\u001b[39m\u001b[3m\u001b[2m ops per second \u001b[22m\u001b[23m"
+        + EOL
     );
   });
 
@@ -86,6 +93,6 @@ describe("formatBenchmark()", function () {
     var benchWithColor = formatBenchmark(benchmark, browser, benchConfig);
     benchConfig.colors = false;
     var benchWithoutColor = formatBenchmark(benchmark, browser, benchConfig);
-    expect(benchWithoutColor).to.equal(chalk.stripColor(benchWithColor));
+    expect(benchWithoutColor).to.equal(stripAnsi(benchWithColor));
   });
 });

--- a/test/spec/formatting/format-suite-heading.spec.js
+++ b/test/spec/formatting/format-suite-heading.spec.js
@@ -1,5 +1,5 @@
 var expect = require("chai").expect;
-var chalk = require("chalk");
+var stripAnsi = require("strip-ansi");
 var EOL = require("os").EOL;
 var formatSuiteHeading = require("../../../src/formatting/format-suite-heading");
 var sampleData = require("../sample-data");
@@ -16,31 +16,29 @@ describe("formatSuiteHeading()", function () {
   });
 
   it("should format the suite heading", function () {
-    var formattedSuiteHeading = formatSuiteHeading(
-      suiteName, browser, benchConfig
-    );
+    var formattedSuiteHeading = formatSuiteHeading(suiteName, browser, benchConfig);
     expect(formattedSuiteHeading).to.equal(
-      EOL + "\u001b[1m\u001b[35m                        test suite 1" +
-      "                        \u001b[39m\u001b[22m" + EOL
+      EOL
+        + "\u001b[1m\u001b[35m                        test suite 1"
+        + "                        \u001b[39m\u001b[22m"
+        + EOL
     );
   });
 
   it("should adjust padding based on terminalWidth", function () {
     benchConfig.terminalWidth = 100;
-    var formattedSuiteHeading = formatSuiteHeading(
-      suiteName, browser, benchConfig
-    );
+    var formattedSuiteHeading = formatSuiteHeading(suiteName, browser, benchConfig);
     expect(formattedSuiteHeading).to.equal(
-      EOL + "\u001b[1m\u001b[35m                                            test suite 1" +
-      "                                            \u001b[39m\u001b[22m" + EOL
+      EOL
+        + "\u001b[1m\u001b[35m                                            test suite 1"
+        + "                                            \u001b[39m\u001b[22m"
+        + EOL
     );
   });
 
   it("should strip colors if colors set to false", function () {
     benchConfig.colors = false;
-    var formattedSuiteHeading = formatSuiteHeading(
-      suiteName, browser, benchConfig
-    );
-    expect(formattedSuiteHeading).to.equal(chalk.stripColor(formattedSuiteHeading));
+    var formattedSuiteHeading = formatSuiteHeading(suiteName, browser, benchConfig);
+    expect(formattedSuiteHeading).to.equal(stripAnsi(formattedSuiteHeading));
   });
 });

--- a/test/spec/formatting/format-suite-summary.spec.js
+++ b/test/spec/formatting/format-suite-summary.spec.js
@@ -1,5 +1,5 @@
 var expect = require("chai").expect;
-var chalk = require("chalk");
+var stripAnsi = require("strip-ansi");
 var EOL = require("os").EOL;
 var formatSuiteSummary = require("../../../src/formatting/format-suite-summary");
 var sampleData = require("../sample-data");
@@ -16,27 +16,31 @@ describe("formatSuiteSummary()", function () {
   });
 
   it("should format the suite summary", function () {
-    var formattedSuiteSummary = formatSuiteSummary(
-      suite, benchConfig
-    );
+    var formattedSuiteSummary = formatSuiteSummary(suite, benchConfig);
     expect(formattedSuiteSummary).to.equal(
-      EOL + "     \u001b[4mbenchmark 5\u001b[24m was \u001b[1m\u001b[4m1.25" +
-      "\u001b[24m\u001b[22m times as fast as \u001b[4mbenchmark 4\u001b[24m      " + EOL
+      EOL
+        + "     \u001b[4mbenchmark 5\u001b[24m was \u001b[1m\u001b[4m1.25"
+        + "\u001b[24m\u001b[22m times as fast as \u001b[4mbenchmark 4\u001b[24m      "
+        + EOL
     );
   });
 
   it("should format the suite summary with browser", function () {
     benchConfig.showBrowser = true;
-    var formattedSuiteSummary = formatSuiteSummary(
-      suite, benchConfig
-    );
+    var formattedSuiteSummary = formatSuiteSummary(suite, benchConfig);
     expect(formattedSuiteSummary).to.equal(
-      EOL + "\u001b[34m[PhantomJS 2.1.1 (Mac OS X 0.0.0)]      \u001b[39m" + EOL +
-      "\u001b[4mbenchmark 4\u001b[24m was \u001b[1m\u001b[4m2\u001b[24m\u001b[22m " +
-      "times as fast as \u001b[4mbenchmark 2\u001b[24m" + EOL + EOL +
-      "\u001b[34m[Chrome 52.0.2743.116 (Mac OS X 10.11.6)]\u001b[39m" + EOL +
-      "\u001b[4mbenchmark 5\u001b[24m was \u001b[1m\u001b[4m1.67\u001b[24m\u001b[22m" +
-      " times as fast as \u001b[4mbenchmark 3\u001b[24m" + EOL
+      EOL
+        + "\u001b[34m[PhantomJS 2.1.1 (Mac OS X 0.0.0)]      \u001b[39m"
+        + EOL
+        + "\u001b[4mbenchmark 4\u001b[24m was \u001b[1m\u001b[4m2\u001b[24m\u001b[22m "
+        + "times as fast as \u001b[4mbenchmark 2\u001b[24m"
+        + EOL
+        + EOL
+        + "\u001b[34m[Chrome 52.0.2743.116 (Mac OS X 10.11.6)]\u001b[39m"
+        + EOL
+        + "\u001b[4mbenchmark 5\u001b[24m was \u001b[1m\u001b[4m1.67\u001b[24m\u001b[22m"
+        + " times as fast as \u001b[4mbenchmark 3\u001b[24m"
+        + EOL
     );
   });
 
@@ -45,6 +49,6 @@ describe("formatSuiteSummary()", function () {
     var summaryWithColor = formatSuiteSummary(suite, benchConfig);
     benchConfig.colors = false;
     var summaryWithoutColor = formatSuiteSummary(suite, benchConfig);
-    expect(summaryWithoutColor).to.equal(chalk.stripColor(summaryWithColor));
+    expect(summaryWithoutColor).to.equal(stripAnsi(summaryWithColor));
   });
 });


### PR DESCRIPTION
Hello, this small PR: 

+ Updates old dependencies.
+ Runs the latest `eslint --fix` over the project.
+ Applies the breaking change from Chalk 2.0 to replace `chalk.stripColor` with `strip-ansi` (https://github.com/chalk/chalk/commit/04cae226cc0fc11fd7898f3fa91fdc4a3b3e496b).

Thank you for creating this reporter.

/cc @rawrmonstar 