### PR TITLE
Pretty-print Hz

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,18 +32,18 @@
     "benchmarkjs"
   ],
   "dependencies": {
-    "chalk": "^2.4.2",
-    "lodash": "^4.15.0",
-    "strip-ansi": "5.0.0"
+    "chalk": "^3.0.0",
+    "lodash": "^4.17.15",
+    "strip-ansi": "6.0.0"
   },
   "devDependencies": {
-    "builder": "^4.0.0",
+    "builder": "^5.0.0",
     "chai": "^4.2.0",
-    "eslint": "^5.12.1",
+    "eslint": "^6.6.0",
     "eslint-config-formidable": "^4.0.0",
-    "eslint-plugin-filenames": "^1.1.0",
-    "eslint-plugin-import": "^2.15.0",
-    "eslint-plugin-promise": "4.0.1",
-    "mocha": "^5.2.0"
+    "eslint-plugin-filenames": "^1.3.2",
+    "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-promise": "4.2.1",
+    "mocha": "^6.2.2"
   }
 }

--- a/src/formatting/format-benchmark.js
+++ b/src/formatting/format-benchmark.js
@@ -23,7 +23,7 @@ var getFormattedDecorator = function (decorator, style) {
  * @private
  */
 var getFormattedHz = function (hz, hzWidth, style) {
-  return style.hz(_.padStart(Math.round(hz), hzWidth));
+  return style.hz(_.padStart(Math.round(hz), hzWidth).toLocaleString());
 };
 
 /**


### PR DESCRIPTION
Just adding .toLocaleString() to the getFormattedHz function to render the Hz in a human readable way (for me that means adding commas). dependencies had to be updated to run in node 12.13.0.